### PR TITLE
Update python version to 2.7.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14-slim
+FROM python:2.7.16-slim-jessie
 
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r sentry && useradd -r -m -g sentry sentry


### PR DESCRIPTION
This bump is to include a fix for https://github.com/debuerreotype/docker-debian-artifacts/issues/66, which was breaking the deploy.